### PR TITLE
fix: use full contractId as SIP-018 domain name

### DIFF
--- a/packages/stackflow-agent/src/aibtc-adapter.js
+++ b/packages/stackflow-agent/src/aibtc-adapter.js
@@ -163,15 +163,17 @@ function deriveSip018Domain(contract) {
     return { name: "stackflow", version: "1.0.0" };
   }
 
-  const [, rawName = contractText] = contractText.split(".");
-  const name = rawName || "stackflow";
-
-  const versionMatch = name.match(/(\d+)-(\d+)-(\d+)$/);
+  // The Clarity contract defines its domain as:
+  //   { name: (to-ascii? current-contract), version: "0.6.0", chain-id: chain-id }
+  // `current-contract` serializes as the full principal: "SP....contract-name".
+  // Use the full contractId as the domain name to match on-chain verification.
+  const [, contractName = contractText] = contractText.split(".");
+  const versionMatch = contractName.match(/(\d+)-(\d+)-(\d+)$/);
   const version = versionMatch
     ? `${versionMatch[1]}.${versionMatch[2]}.${versionMatch[3]}`
     : "1.0.0";
 
-  return { name, version };
+  return { name: contractText, version };
 }
 
 export class AibtcWalletAdapter {


### PR DESCRIPTION
## Summary

- `deriveSip018Domain` was stripping the contract address and using only the contract-name segment (e.g. `stackflow-sbtc-0-6-0`) as the SIP-018 domain `name`
- The Clarity contract defines its domain as `{ name: (to-ascii? current-contract), ... }` — `current-contract` serializes as the **full principal**: `SP....contract-name`
- Using the wrong domain name produces a signature hash that does not match what the contract verifies on-chain, causing any dispute submission or cooperative close relying on agent-generated signatures to fail

## Fix

Pass the full `contractId` as the domain name. Version is still derived from the contract-name segment as before.

## Impact

- Disputes submitted by agents using `AibtcWalletAdapter` will now produce signatures that verify correctly on-chain
- Off-chain signature exchange between agents is unaffected (verification happens on-chain)

## Test plan

- [ ] Verify `sip018_verify` accepts the signature against the deployed mainnet contract's domain
- [ ] Force-close + dispute end-to-end test with a live pipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)